### PR TITLE
Update to gimp3

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -19,7 +19,7 @@ jobs:
       if: always()
       run: |
         sed -i 's/DownloadUser/#DownloadUser/g' /etc/pacman.conf
-        pacman -Syu --noconfirm base-devel curl desktop-file-utils git wget libheif alsa-lib \
+        pacman -Syu --noconfirm base-devel curl desktop-file-utils git wget libheif alsa-lib gvfs \
           base-devel patchelf gtk3 strace gimp ffmpeg ghostscript llvm xorg-server-xvfb librsvg
 
         # Artix repos don't have zsyc

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         sed -i 's/DownloadUser/#DownloadUser/g' /etc/pacman.conf
         pacman -Syu --noconfirm base-devel curl desktop-file-utils git wget libheif alsa-lib gvfs \
-          base-devel patchelf gtk3 strace gimp ffmpeg ghostscript llvm xorg-server-xvfb librsvg
+          base-devel patchelf gtk3 strace gimp ffmpeg ghostscript llvm xorg-server-xvfb librsvg cfitsio
 
         # Artix repos don't have zsyc
         wget https://london.mirror.pkgbuild.com/extra/os/x86_64/zsync-0.6.2-5-x86_64.pkg.tar.zst

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -19,7 +19,7 @@ jobs:
       if: always()
       run: |
         sed -i 's/DownloadUser/#DownloadUser/g' /etc/pacman.conf
-        pacman -Syu --noconfirm base-devel curl desktop-file-utils git wget libheif \
+        pacman -Syu --noconfirm base-devel curl desktop-file-utils git wget libheif alsa-lib \
           base-devel patchelf gtk3 strace gimp ffmpeg ghostscript llvm xorg-server-xvfb librsvg
 
         # Artix repos don't have zsyc

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -19,7 +19,7 @@ jobs:
       if: always()
       run: |
         sed -i 's/DownloadUser/#DownloadUser/g' /etc/pacman.conf
-        pacman -Syu --noconfirm base-devel curl desktop-file-utils git wget \
+        pacman -Syu --noconfirm base-devel curl desktop-file-utils git wget libheif \
           base-devel patchelf gtk3 strace gimp ffmpeg ghostscript llvm xorg-server-xvfb librsvg
 
         # Artix repos don't have zsyc

--- a/gimp-appimage.sh
+++ b/gimp-appimage.sh
@@ -36,7 +36,7 @@ ln -s ./"$ICON"    ./.DirIcon
 # ADD LIBRARIES
 wget "$LIB4BN" -O ./lib4bin
 chmod +x ./lib4bin
-./lib4bin -p -v -s -k \
+./lib4bin -p -v -k \
 	/usr/bin/gimp* \
 	/usr/lib/libgimp* \
 	/usr/lib/gdk-pixbuf-*/*/*/* \

--- a/gimp-appimage.sh
+++ b/gimp-appimage.sh
@@ -36,7 +36,7 @@ ln -s ./"$ICON"    ./.DirIcon
 # ADD LIBRARIES
 wget "$LIB4BN" -O ./lib4bin
 chmod +x ./lib4bin
-./lib4bin -p -v -k \
+./lib4bin -p -v -k -r \
 	/usr/bin/gimp* \
 	/usr/lib/libgimp* \
 	/usr/lib/gdk-pixbuf-*/*/*/* \

--- a/gimp-appimage.sh
+++ b/gimp-appimage.sh
@@ -36,7 +36,7 @@ ln -s ./"$ICON"    ./.DirIcon
 # ADD LIBRARIES
 wget "$LIB4BN" -O ./lib4bin
 chmod +x ./lib4bin
-xvfb-run -a -- ./lib4bin -p -v -s -k -e \
+./lib4bin -p -v -s -k \
 	/usr/bin/gimp* \
 	/usr/lib/libgimp* \
 	/usr/lib/gdk-pixbuf-*/*/*/* \

--- a/gimp-appimage.sh
+++ b/gimp-appimage.sh
@@ -46,6 +46,7 @@ chmod +x ./lib4bin
 	/usr/lib/gegl-*/* \
 	/usr/lib/libheif/* \
 	/usr/lib/libaa* \
+	/usr/lib/libasound.so* \
 	/usr/lib/libmng* \
 	/usr/lib/libgs* \
 	/usr/lib/libslang* \

--- a/gimp-appimage.sh
+++ b/gimp-appimage.sh
@@ -77,7 +77,7 @@ done
 # FIXME we should avoid this because it results in a need to change the current workign dir
 # For some reason setting BABL_PATH and GEGL_PATH causes a ton of errors to show up
 # Lets use the good old binary patching
-sed -i 's|/usr|././|' ./shared/lib/libbabl* ./shared/lib/libgegl*
+sed -i 's|/usr/lib|././/lib|' ./shared/lib/libbabl* ./shared/lib/libgegl*
 
 # PREPARE SHARUN
 echo 'SHARUN_WORKING_DIR=${SHARUN_DIR}

--- a/gimp-appimage.sh
+++ b/gimp-appimage.sh
@@ -44,6 +44,7 @@ chmod +x ./lib4bin
 	/usr/lib/gio/*/* \
 	/usr/lib/babl-*/* \
 	/usr/lib/gegl-*/* \
+	/usr/lib/libheif/* \
 	/usr/lib/libaa* \
 	/usr/lib/libmng* \
 	/usr/lib/libgs* \

--- a/gimp-appimage.sh
+++ b/gimp-appimage.sh
@@ -74,11 +74,19 @@ for plugin in $bins_to_find; do
 	echo "Sharan $plugin"
 done
 
+# FIXME we should avoid this because it results in a need to change the current workign dir
+# For some reason setting BABL_PATH and GEGL_PATH causes a ton of errors to show up
+# Lets use the good old binary patching
+sed -i 's|/usr|././|' ./shared/lib/libbabl* ./shared/lib/libgegl*
+
 # PREPARE SHARUN
-echo 'GIMP3_DATADIR=${SHARUN_DIR}/share/gimp/3.0
+echo 'SHARUN_WORKING_DIR=${SHARUN_DIR}
+GIMP3_DATADIR=${SHARUN_DIR}/share/gimp/3.0
 GIMP3_SYSCONFDIR=${SHARUN_DIR}/etc/gimp/3.0
 GIMP3_LOCALEDIR=${SHARUN_DIR}/share/locale
-GIMP3_PLUGINDIR=${SHARUN_DIR}/shared/lib/gimp/3.0' > ./.env
+GIMP3_PLUGINDIR=${SHARUN_DIR}/shared/lib/gimp/3.0
+unset BABL_PATH
+unset GEGL_PATH' > ./.env
 
 ln ./sharun ./AppRun
 ./sharun -g

--- a/gimp-appimage.sh
+++ b/gimp-appimage.sh
@@ -42,6 +42,8 @@ chmod +x ./lib4bin
 	/usr/lib/gio/*/* \
 	/usr/lib/babl-*/* \
 	/usr/lib/gegl-*/* \
+	/usr/lib/gvfs/* \
+	/usr/lib/libgthread-2.0.so* \
 	/usr/lib/libheif/* \
 	/usr/lib/libaa* \
 	/usr/lib/libasound.so* \

--- a/gimp-appimage.sh
+++ b/gimp-appimage.sh
@@ -36,7 +36,7 @@ ln -s ./"$ICON"    ./.DirIcon
 # ADD LIBRARIES
 wget "$LIB4BN" -O ./lib4bin
 chmod +x ./lib4bin
-./lib4bin -p -v -k -r \
+./lib4bin -p -v -k -s \
 	/usr/bin/gimp* \
 	/usr/lib/libgimp* \
 	/usr/lib/gdk-pixbuf-*/*/*/* \
@@ -67,19 +67,17 @@ cp -rvn /usr/lib/gimp    ./shared/lib
 
 # sharun the gimp plugins
 echo "Sharunning the gimp plugins..."
-mkdir -p ./shared/lib/gimp/3.0/shared/bin
-cp ./sharun ./shared/lib/gimp/3.0
 ( cd ./shared/lib/gimp/3.0
 	for plugin in ./plug-ins/*/*; do
 		if file "$plugin" | grep -i 'elf.*executable'; then
-			mv "$plugin" ./shared/bin && ln -s ../../sharun "$plugin"
+			mv "$plugin" ../../../bin \
+				&& ln -s ../../../../../../sharun  "$plugin"
 			echo "Sharan $plugin"
 		else
 			echo "$plugin is not a binary, skipping..."
 		fi
 	done
 )
-ln -s ../../../ ./shared/lib/gimp/3.0/shared/lib
 
 # PREPARE SHARUN
 echo 'GIMP3_DATADIR=${SHARUN_DIR}/share/gimp/3.0

--- a/gimp-appimage.sh
+++ b/gimp-appimage.sh
@@ -96,7 +96,7 @@ echo "Generating AppImage..."
 ./uruntime --appimage-mkdwarfs -f \
 	--set-owner 0 --set-group 0 \
 	--no-history --no-create-timestamp \
-	--compression zstd:level=22 -S24 -B32 \
+	--compression zstd:level=22 -S23 -B32 \
 	--header uruntime \
 	-i ./AppDir -o "$PACKAGE"-"$VERSION"-"$ARCH".AppImage
 

--- a/gimp-appimage.sh
+++ b/gimp-appimage.sh
@@ -88,6 +88,9 @@ cd ..
 wget -q "$URUNTIME" -O ./uruntime
 chmod +x ./uruntime
 
+# Keep the mount point (speeds up launch time)
+sed -i 's|URUNTIME_MOUNT=[0-9]|URUNTIME_MOUNT=0|' ./uruntime
+
 #Add udpate info to runtime
 echo "Adding update information \"$UPINFO\" to runtime..."
 ./uruntime --appimage-addupdinfo "$UPINFO"


### PR DESCRIPTION
@VHSgunzo For some reason while the application seems to work fine, there is a lot of babl and gegl errors in the terminal that I can't explain 🤔

Even if deployed on my PC with strace mode, I get those errors as well, but I do not get the errors when I try the native package. 

I have a feeling this is related to `argv0`, because that's the only thing that's different in the appimage vs native. 

[Artifact](https://github.com/Samueru-sama/GIMP-AppImage-test/releases/tag/continuous)